### PR TITLE
Error messages should include file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ module.exports = function(name) {
     }
     catch (err) {
       err.fileName = file.path
-      this.emit('error', new gutil.PluginError('gulp-msx', err))
+      this.emit('error', new gutil.PluginError('gulp-msx',
+        gutil.colors.magenta(path.relative(file.cwd, file.path)) + ' ' + err.message))
     }
 
     this.push(file)


### PR DESCRIPTION
I'm developing a boilerplate project for mithril framework. When building .jsx files, it's hard to see which file have syntax error. The plugin should better include file path in error messages.
